### PR TITLE
Refactored app.js by moving MongoDB and security packages to server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"start": "nodemon src/app.js",
-		"server": "nodemon src/server.js"
+		"start": "nodemon src/app.js"
 	},
 	"author": "",
 	"license": "ISC",

--- a/src/app.js
+++ b/src/app.js
@@ -1,15 +1,9 @@
-require('dotenv').config();
-const express = require('express')
-app = express()
+const app = require('./server');
 require('express-async-errors');
-
-const cors = require('cors')
 const http = require('http')
-const favicon = require('express-favicon');
-const logger = require('morgan')
 const { Server } = require('socket.io')
-
 const server = http.createServer(app)
+
 const io = new Server(server, {
     cors: {
         origin: "http://localhost:3000",
@@ -17,16 +11,7 @@ const io = new Server(server, {
     }
 })
 
-app.use(express.json());
-app.use(cors());
-app.use(express.urlencoded({ extended: false }));
-app.use(logger('dev'));
-app.use(express.static('public'))
-app.use(favicon(__dirname + '/public/favicon.ico'));
-
-
 let rooms = []
-
 /* initial user connection to sockets */
 io.on("connection", (socket) => {
     // maxRooms = rooms.filter(room => room.players.length<10)
@@ -142,7 +127,7 @@ io.on("connection", (socket) => {
     })
 })
 
-const port = 3001;
+const port = process.env.PORT || 4000;
 const start = () => {
     try {
         server.listen(port, () =>
@@ -151,6 +136,4 @@ const start = () => {
         console.log(error);
     }
 };
-
 start();
-module.exports = app;

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,23 @@
-const app = require("./app");
+/* module setup */
 require('dotenv').config();
+const express = require('express')
 require('express-async-errors');
 const session = require('express-session');
 const MongoDBStore = require("connect-mongodb-session")(session);
 const connectDB = require('./db/connect');
+app = express()
+
+/** extra security packages */
+const cors = require('cors')
+const favicon = require('express-favicon');
+const logger = require('morgan')
+
+app.use(express.json());
+app.use(cors());
+app.use(express.urlencoded({ extended: false }));
+app.use(logger('dev'));
+app.use(express.static('public'))
+app.use(favicon(__dirname + '/public/favicon.ico'));
 
 /* routers */
 const authRouter = require('./routes/auth');
@@ -32,7 +46,7 @@ store.on("error", function (error) {
 const port = process.env.PORT || 8000;
 const start = async () => {
   try {
-    await connectDB(process.env.MONGO_URI);
+    await connectDB(url);
     app.listen(port, () =>
       console.log(`server is listening on port ${port}...`)
     );
@@ -42,3 +56,4 @@ const start = async () => {
 };
 
 start();
+module.exports = app;


### PR DESCRIPTION
modified start script to  npm start
updated app.js port from 3001 to 4000

## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

1. This redirects the port to 4000 instead of 3001 for app.js in backend, reducing the possibility of listening to the same port at the same time.

2. Now, npm run server is replaced by **npm start** 

3.  To assist with file readability and consistency, mongoDB related code and security packages are now in server.js.
app.js only includes **socket** related code. 

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

<!-- Provide steps the other team members and mentors need to follow to properly test your additions. -->

use npm start on **backend** and **frontend** repos
